### PR TITLE
[bitwise.h] incorrect indirection in array union/overlays

### DIFF
--- a/API/Z/types/bitwise.h
+++ b/API/Z/types/bitwise.h
@@ -28,7 +28,7 @@ Released under the terms of the GNU Lesser General Public License v3. */
 
 #		ifdef Z_SINT8
 			zsint8 sint8_value;
-			zsint8 sint8_array;
+			zsint8 sint8_array[1];
 
 			struct {zsint8 at_0;
 			} sint8_values;
@@ -52,7 +52,7 @@ Released under the terms of the GNU Lesser General Public License v3. */
 
 #		ifdef Z_SINT16
 			zsint16 sint16_value;
-			zsint16 sint16_array;
+			zsint16 sint16_array[1];
 
 			struct {zsint16 at_0;
 			} sint16_values;
@@ -105,7 +105,7 @@ Released under the terms of the GNU Lesser General Public License v3. */
 
 #		ifdef Z_SINT32
 			zsint32 sint32_value;
-			zsint32 sint32_array;
+			zsint32 sint32_array[1];
 
 			struct {zsint32 at_0;
 			} sint32_values;
@@ -205,7 +205,7 @@ Released under the terms of the GNU Lesser General Public License v3. */
 
 #		ifdef Z_SINT64
 			zsint64 sint64_value;
-			zsint64 sint64_array;
+			zsint64 sint64_array[1];
 
 			struct {zsint64 at_0;
 			} sint64_values;
@@ -366,7 +366,7 @@ Released under the terms of the GNU Lesser General Public License v3. */
 
 #		ifdef Z_SINT128
 			zsint128 sint128_value;
-			zsint128 sint128_array;
+			zsint128 sint128_array[1];
 
 			struct {zsint128 at_0;
 			} sint128_values;


### PR DESCRIPTION
Not sure if this file of overlaid union patterns was automatically generated, but there appears to be an oversight or error in formulating the `array` interpretations in several cases when there is a single element. I believe your intention is as I have fixed it, since a few of the similar cases were already correct. And I assume you didn't intend, or don't want inconsistent "fitting" techniques between the signed and unsigned interpretations of the same size/pattern(s), as is at the moment.

Feel free to discard or ignore this PR if it's not helpful.

---

### Legal notice _(do not delete)_

Contributors are required to assign copyright to the original author of the project so that he retains full ownership. This ensures that other entities can use the software more easily, as they only need to deal with a single copyright holder. It also provides the original author with the assurance that he can make decisions in the future without needing to consult or obtain consent from all contributors.

By submitting this pull request (PR), you agree to the following:

> You hereby assign the copyright in the code included in this pull request to the original author of the Zeta library, Manuel Sainz de Baranda y Goñi, to be licensed under the same terms as the rest of the code. You also agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
